### PR TITLE
Package psgen using a nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,84 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717050755,
+        "narHash": "sha256-C9IEHABulv2zEDFA+Bf0E1nmfN4y6MIUe5eM2RCrDC0=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "31b6d2e40b36456e792cd6cf50d5a8ddd2fa59a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720823163,
+        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-24.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-24.05";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.gomod2nix = {
+    url = "github:tweag/gomod2nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs = {self, ...}@inputs:
+    let
+
+      # Generate a user-friendly version number.
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = with inputs.flake-utils.lib.system; [
+        x86_64-linux
+        # Below not tested but no reason why they shouldn't work.
+        x86_64-darwin
+        aarch64-linux
+        aarch64-darwin
+      ];
+
+    in inputs.flake-utils.lib.eachSystem supportedSystems (system:
+      let
+
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ inputs.gomod2nix.overlays.default ];
+        };
+
+        psgen = pkgs.buildGoApplication {
+          pname = "psgen";
+          inherit version;
+          src = ./.;
+          pwd = ./.;
+          modules = ./gomod2nix.toml;
+          meta = with pkgs.lib; {
+            description = "A theorem proving type language which generates SystemVerilog and TCL.";
+            longDescription = ''
+              psgen is a theorem proving type language which generates SystemVerilog and TCL.
+              It dramatically simplifies case splitting, inductive proofs and similar strategies often found in formal verification.
+            '';
+            mainProgram = "psgen";
+            homepage = "https://github.com/mndstrmr/psgen";
+            maintainers = [ ];
+            # license = ;
+          };
+        };
+
+        psgen_env = pkgs.mkGoEnv {inherit (psgen) pwd modules;};
+
+      in {
+
+        packages = {
+          inherit psgen;
+          default = psgen;
+        };
+        devShells = {
+          default = pkgs.mkShellNoCC {
+            buildInputs = [
+              psgen_env
+            ];
+          };
+        };
+        apps = let
+          mkApp = package: {type = "app"; program = "${package}/bin/${package.meta.mainProgram or package.pname}";};
+          psgen_app = mkApp psgen;
+          update = mkApp pkgs.gomod2nix;
+        in rec {
+          psgen = psgen_app;
+          default = psgen_app;
+          inherit update;
+        };
+
+      });
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,3 @@
+schema = 3
+
+[mod]


### PR DESCRIPTION
This adds a nix flake which packages `psgen` and its dependencies for development and external consumption.

Nix is, among other things, a powerful build tool that aims to declaratively specify a project's dependencies and then allow building it in a reproducible, hermetic environment. While this project doesn't have many dependencies (yet!), nix makes managing everything easy if you wanted to add them, and the nix 'flake' format provides a consistent interface for projects to assemble their dependencies.

After [installing nix](https://zero-to-nix.com/start/install), this change would allow other projects to import `psgen` into their own nix flakes, or to get access to psgen using the nix CLI with the following workflows...
```
// Working in the psgen repo...
/////////////////////////////////////////////////

// Enter a subshell with all psgen development dependencies
nix develop # Builds a sandboxed version of go + deps based on go.mod, and adds it to your path.
go build
./psgen -path examples/btype.proof -root btype
exit # leave subshell

// Build and run psgen
nix run . -- -path examples/btype.proof -root btype

// Working outside the psgen repo...
//////////////////////////////////////////////////////////

// Build and run psgen
nix run github:mndstrmr/psgen -- -path <> ...

// Build psgen, and enter a subshell with it on your path
nix shell github:mndstrmr/psgen
psgen -path <> ...
exit # leave subshell

// Note. the above commands can be tested against this PR, which just requires a little extra syntax to specify a branch for nix to fetch from.
// e.g.
// nix run github:hcallahan-lowrisc/psgen?ref=nix_flake_package
// -> s;mndstrmr/psgen;hcallahan-lowrisc/psgen?ref=nix_flake_package;g
```

All of this code shouldn't require any maintenance for normal development. However, if new dependencies are added to go.mod, the command `nix run .#update` would be required to re-generate the `gomod2nix.toml` file.